### PR TITLE
Gamepad support on linux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ notes.*
 /*.c
 /*.h
 *.d
+game
+game.*

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ OPTIMIZE_FLAGS:=-MD -Os -s -fno-asynchronous-unwind-tables -fno-tree-loop-distri
 OPTIMIZED_EXE:=$(EXE_NAME).opt
 COMPRESSED_EXE:=$(EXE_NAME).upx
 ifeq ($(UNAME),Linux)
-LIBS=-lX11 -lm #-lasound
+LIBS=-lX11 -lm -ludev#-lasound
 PLATFORM:=PLATFORM_Linux
 endif # UNAME == Linux
 endif # OS != Windows_NT
@@ -31,7 +31,7 @@ build: $(EXE) .PHONY
 
 
 $(EXE): src/*.c includes/*.h
-	$(CC) src/*.c $(LIBS) -D$(PLATFORM) -Wall -Wextra -Iincludes -o $@
+	$(CC) src/*.c $(LIBS) -D$(PLATFORM) -Wall -Wextra -Iincludes -g -o $@
 
 run: $(EXE) .PHONY
 	./$(EXE)

--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,9 @@ $(EXE): src/*.c includes/*.h
 run: $(EXE) .PHONY
 	./$(EXE)
 
+valgrind: $(EXE) .PHONY
+	valgrind --leak-check=full -s ./$(EXE)
+
 release: $(OPTIMIZED_EXE) .PHONY
 
 $(OPTIMIZED_EXE): src/*.c includes/*.h

--- a/includes/gamepad.h
+++ b/includes/gamepad.h
@@ -2,6 +2,7 @@
 #define Gamepad_H
 
 #include "types.h"
+#include "list.h"
 
 typedef struct Window Window;
 
@@ -108,6 +109,8 @@ typedef struct Gamepad {
     int playerID;
     GamepadNative* native;
 } Gamepad;
+
+DecList(Gamepad, GamepadList)
 
 // `WindowGetGamepad` retrieves a players gamepad given their playerID (most
 // often 1-4).

--- a/includes/gamepad.h
+++ b/includes/gamepad.h
@@ -72,6 +72,7 @@ typedef enum PACK_ENUM GamepadButton {
     // `GAMEPAD_BUTTON_COUNT` is not a gamepad button. It denotes the number of
     // gamepad buttons available to check.
     GAMEPAD_BUTTON_COUNT,
+    GAMEPAD_BUTTON_INVALID,
 } GamepadButton;
 
 // `GamepadAxis` represents an analog axis on a standard gamepad controller.
@@ -104,7 +105,9 @@ typedef struct Gamepad {
     uint32 pButtons;
 
     float32 leftMotor;
+    float32 pLeftMotor;
     float32 rightMotor;
+    float32 pRightMotor;
 
     int playerID;
     GamepadNative* native;
@@ -112,11 +115,11 @@ typedef struct Gamepad {
 
 DecList(Gamepad, GamepadList)
 
-// `WindowGetGamepad` retrieves a players gamepad given their playerID (most
-// often 1-4).
-//
-// If the playerID is more than supported, this function returns `nil`.
-Gamepad* WindowGetGamepad(Window* window, int playerID);
+    // `WindowGetGamepad` retrieves a players gamepad given their playerID (most
+    // often 1-4).
+    //
+    // If the playerID is more than supported, this function returns `nil`.
+    Gamepad* WindowGetGamepad(Window* window, int playerID);
 
 // `WindowGetFirstConnectedGamepad` attempts to retrieve the first gamepad that
 // was connected.
@@ -163,6 +166,6 @@ float32 GamepadAxisValue(Gamepad* gamepad, GamepadAxis axis);
 // The left and right vibration motor may not be the same. For example, on XBox
 // controllers and PS4 DualShocks, the left motor is for low frequency
 // vibrations while the right motor is for high frequency vibrations.
-void GamepadSetVibration(float32 leftMotor, float32 rightMotor);
+void GamepadSetVibration(Gamepad* gamepad, float32 leftMotor, float32 rightMotor);
 
 #endif  // Gamepad_H

--- a/includes/gamepad.h
+++ b/includes/gamepad.h
@@ -113,20 +113,32 @@ typedef struct Gamepad {
     GamepadNative* native;
 } Gamepad;
 
-DecList(Gamepad, GamepadList)
+DecList(Gamepad, GamepadList);
 
-    // `WindowGetGamepad` retrieves a players gamepad given their playerID (most
-    // often 1-4).
-    //
-    // If the playerID is more than supported, this function returns `nil`.
-    Gamepad* WindowGetGamepad(Window* window, int playerID);
+// `WindowGetGamepad` retrieves a players gamepad given their playerID (most
+// often 1-4).
+//
+// If the playerID is more than supported, this function returns `nil`.
+//
+// Note: The returned pointer is still owned by Mino and it's location can be
+// changed. Instead, you may want to hold onto the playerID and retrieve the
+// players gamepad on each update.
+Gamepad* WindowGetGamepad(Window* window, int playerID);
 
 // `WindowGetFirstConnectedGamepad` attempts to retrieve the first gamepad that
 // was connected.
 //
 // If no gamepads have been connected, this returns `nil`. The gamepad returned
 // can also disconnect, but this function will still return that gamepad.
+//
+// Note: The returned pointer is still owned by Mino and it's location can be
+// changed. 
 Gamepad* WindowGetFirstConnectedGamepad(Window* window);
+
+// `GamepadCount` returns the number of gamepads the window is keeping track of.
+//
+// Not all gamepads counted may be connected.
+int GamepadCount(Window *window);
 
 // `GamepadConnected` checks if the current gamepad is connected.
 bool GamepadConnected(Gamepad* gamepad);

--- a/includes/list.h
+++ b/includes/list.h
@@ -1,0 +1,59 @@
+#ifndef List_H
+#define List_H
+
+#include "types.h"
+
+typedef struct List List;
+
+bool ListInit(List* list, int itemSize, int len, int cap);
+void* ListGet(struct List* list, int index);
+void ListFree(List* list);
+bool ListGrow(List* list, int newCap);
+bool ListPush(List* list, void* item);
+bool ListPop(List* list, void* dest);
+bool ListUnshift(List* list, void* item);
+bool ListShift(List* list, void* dest);
+
+#define DecList(Type, Name)                        \
+    typedef struct Name {                          \
+        Type* data;                                \
+        const int itemSize;                        \
+        int len;                                   \
+        int cap;                                   \
+    } Name;                                        \
+    bool Name##Init(Name* list, int len, int cap); \
+    Type* Name##Get(struct Name* list, int index); \
+    void Name##Free(Name* list);                   \
+    bool Name##Grow(Name* list, int newCap);       \
+    bool Name##Push(Name* list, Type item);        \
+    bool Name##Pop(Name* list, Type* dest);        \
+    bool Name##Unshift(Name* list, Type item);     \
+    bool Name##Shift(Name* list, Type* dest);
+
+#define DefList(Type, Name)                                       \
+    extern inline bool Name##Init(Name* list, int len, int cap) { \
+        return ListInit((List*)list, sizeof(Type), len, cap);     \
+    }                                                             \
+    extern inline Type* Name##Get(struct Name* list, int index) { \
+        return &list->data[index];                                \
+    }                                                             \
+    extern inline void Name##Free(Name* list) {                   \
+        ListFree((List*)list);                                    \
+    }                                                             \
+    extern inline bool Name##Grow(Name* list, int newCap) {       \
+        return ListGrow((List*)list, newCap);                     \
+    }                                                             \
+    extern inline bool Name##Push(Name* list, Type item) {        \
+        return ListPush((List*)list, &item);                      \
+    }                                                             \
+    extern inline bool Name##Pop(Name* list, Type* dest) {        \
+        return ListPop((List*)list, dest);                        \
+    }                                                             \
+    extern inline bool Name##Unshift(Name* list, Type item) {     \
+        return ListUnshift((List*)list, &item);                   \
+    }                                                             \
+    extern inline bool Name##Shift(Name* list, Type* dest) {      \
+        return ListShift((List*)list, dest);                      \
+    }
+
+#endif  // List_H

--- a/includes/list.h
+++ b/includes/list.h
@@ -3,23 +3,115 @@
 
 #include "types.h"
 
-typedef struct List List;
+// `List` is a simple, dynamically allocated, array of contiguous memory.
+//
+// Before you use a new list, you should call `ListInit` to initialize the size
+// of each element. Once you do, you can add, index, and remove elements of that
+// size.
+//
+// As memory is dynamically allocated, it is a good idea to call `ListFree` when
+// you are done with this list to free up it's memory. Note that after you call
+// `ListFree`, you can still use the list like normal as it frees the data and
+// zeroes the capacity but the list is still valid.
+//
+// See also the `DecList` and `DefList` macros for ways to create lists specific
+// to a certain type.
+typedef struct List {
+    byte* const data;
+    const int itemSize;
+    const int len;
+    const int cap;
+} List;
 
+// `ListInit` initializes a blank list with the given `itemSize`. You can
+// specify the initial length and capacity of the list to preallocate memory for
+// this list.
+//
+// This returns true if the allocation was successful, else it returns false.
 bool ListInit(List* list, int itemSize, int len, int cap);
-void* ListGet(struct List* list, int index);
+
+// `ListGet` retrieves an element from this list at the specified index. This
+// returns nil if the index is out of range.
+//
+// Note: The pointer returned from `ListGet` is owned by this list. It may
+// change, especially if you shift, unshift, pop, or grow this list.
+void* ListGet(List* list, int index);
+
+// `ListFree` discards all elements from this list and frees it's memory. Even
+// though the memory is freed, the list is still valid to use without
+// initializing again; it's capacity is simply set to zero (which may mean
+// other operations may need to grow this list again).
+//
+// You should call this when you are finished using this list.
 void ListFree(List* list);
+
+// `ListGrow` tries to grow this list to fit the amount of elements specified by
+// `newCap`. This does not modify the length of the list, rather it allocates
+// more memory to fit more elements, copies the old data, then changes the lists
+// capacity. This allows you to allocate extra memory to minimize calls to the
+// allocator.
+//
+// This returns true if the allocation was successful, else it returns false. If
+// `newCap` is smaller than the current capacity, no changes are made and this
+// returns true.
 bool ListGrow(List* list, int newCap);
+
+// `ListPush` tries to append a new entry and copies the data located by `item`
+// into this list. If the list's capacity is too small to accommodate a new
+// entry, the list is automatically grown by a scale factor of `1.5 * list.cap`.
+//
+// This returns true if appending the entry was successful. If the list was
+// unable to allocate a new entry then this returns false.
 bool ListPush(List* list, void* item);
+
+// `ListPop` removes an entry from the end of the list. if `dest` is not nil,
+// the entry is copied to that location.
+//
+// This returns true if it actually removed an element. It returns false if
+// there are no elements to remove.
 bool ListPop(List* list, void* dest);
+
+// `ListUnshift` tries to prepend a new entry and copies the data located by
+// `item` into this list. If the list's capacity is too small to accommodate a
+// new entry, the list is automatically grown by a scale factor of
+// `1.5 * list.cap`. This is slightly more expensive than pushing as the older
+// data needs to be copied over to accommodate the new entry.
+//
+// This returns true if prepending the entry was successful. If the list was
+// unable to allocate a new entry then this returns false.
 bool ListUnshift(List* list, void* item);
+
+// `ListPop` removes an entry from the beginning of the list. if `dest` is not
+// nil, the entry is copied to that location. This is slightly more expensive
+// than removing from the beginning as the remaining data needs to be copied
+// over.
+//
+// This returns true if it actually removed an element. It returns false if
+// there are no elements to remove.
 bool ListShift(List* list, void* dest);
 
+// `DecList` declares a list with entries of type: `Type` and type name: `Name`.
+// This defines the type but forward declares the functions without
+// implementing or defining them yet (see `DefList`). This allows you to declare
+// lists as a struct instead of a pointer as well as get access to list length
+// and capacity but might necessitate the use of include guards. or
+// `#pragma once`.
+//
+// This is intended to be placed in header files so as not to duplicate the
+// definition of each function.
+//
+// The functions declared by this macro wrap the ordinary `List` type but ensure
+// that the size of entries match the size of `Type` and provide some ergonomics
+// such as passing entries by the entry type instead of by `void*`.
+//
+// Make sure you call the init function before you use the list to ensure that
+// the size of each entry is properly set.
 #define DecList(Type, Name)                        \
     typedef struct Name {                          \
-        Type* data;                                \
+        Type* const data;                          \
         const int itemSize;                        \
-        int len;                                   \
-        int cap;                                   \
+        const int len;                             \
+        const int cap;                             \
     } Name;                                        \
     bool Name##Init(Name* list, int len, int cap); \
     Type* Name##Get(struct Name* list, int index); \
@@ -30,12 +122,23 @@ bool ListShift(List* list, void* dest);
     bool Name##Unshift(Name* list, Type item);     \
     bool Name##Shift(Name* list, Type* dest);
 
+// `DefList` defines the functions of a list declared with `DecList`. The
+// functions defined by this macro wrap the ordinary list functions but ensure
+// that the size of entries math the size of `Type` and provide some ergonomics
+// such as passing entries by the entry type instead of by `void*`.
+//
+// This is intended to be placed in a C function to avoid duplicating the
+// function definitions but it should come after you have declared the list with
+// `DecList`.
+//
+// Make sure you call the init function before you use the list to ensure that
+// the size of each entry is properly set.
 #define DefList(Type, Name)                                       \
     extern inline bool Name##Init(Name* list, int len, int cap) { \
         return ListInit((List*)list, sizeof(Type), len, cap);     \
     }                                                             \
-    extern inline Type* Name##Get(struct Name* list, int index) { \
-        return &list->data[index];                                \
+    extern inline Type* Name##Get(Name* list, int index) {        \
+        return (Type*)ListGet((List*)list, index);                \
     }                                                             \
     extern inline void Name##Free(Name* list) {                   \
         ListFree((List*)list);                                    \

--- a/includes/utils.h
+++ b/includes/utils.h
@@ -1,6 +1,7 @@
 #ifndef Utils_H
 #define Utils_H
 
+#include <stddef.h>
 #include "types.h"
 
 #ifdef NOPRINT
@@ -24,7 +25,8 @@ int printf(const char* restrict format, ...);
 //
 // if `NOPRINT` is defined, this doesn't do anything and simply ignores passed
 // arguments.
-#define println(format, ...) printf(format "\n"__VA_OPT__(, __VA_ARGS__))
+#define println(format, ...) printf("[%s:%d] ~> " format "\n", __FILE__, __LINE__ __VA_OPT__(, __VA_ARGS__)) // __println(__FILE__, __LINE__, format, __VA_ARGS__)
+#define __println(file, line, format, ...) 
 #endif
 
 // `len` gets the length of a constant width array.
@@ -33,10 +35,18 @@ int printf(const char* restrict format, ...);
 // pointer might not be known at compile time.
 #define len(array, type) (sizeof(array) / sizeof(type))
 
+void copy(const void* restrict src, void* restrict dst, size_t size);
+
+// `copyPad` copies as much from `src` into `dst` up to the size specified. If
+// `src` is smaller than size, the rest of `dst` is padded with null bytes 
+// ('\0')
+void copyPad(const void* restrict src, void* restrict dst, size_t size);
+
 // `allocate` easily allocates and initializes to zero a chunk of memory the
 // size of the specified `type`.
 #define allocate(type) (type*)calloc(1, sizeof(type))
 #define allocateN(type, count) (type*)calloc(count, sizeof(type))
+#define reallocateN(pointer, type, count) (type*)realloc(pointer, sizeof(type) * count)
 
 // `bitSet` checks that the bit offset by `index` is set in `bits`.
 bool bitSet(uint64 bits, uint8 index);
@@ -52,5 +62,7 @@ uint64 unsetBit(uint64 bits, uint8 index);
 
 // `clamp` constrains value to be between the `min` and `max`.
 float32 clamp(float32 value, float32 min, float32 max);
+
+bool hasPrefix(const char* text, const char* prefix);
 
 #endif  // Utils_H

--- a/includes/window.h
+++ b/includes/window.h
@@ -4,6 +4,7 @@
 #include "gamepad.h"
 #include "keyboard.h"
 #include "types.h"
+#include "list.h"
 
 // `WindowNative` is the platforms native implementation of a window.
 //
@@ -33,9 +34,7 @@ typedef struct Window {
     byte mousePressed;
     byte pMousePressed;
 
-    Gamepad* firstGamepad;
-    Gamepad* gamepads;
-    int gamepadCount;
+    GamepadList gamepads;
 
     WindowNative* native;
 } Window;

--- a/src/gamepad.c
+++ b/src/gamepad.c
@@ -1,7 +1,10 @@
 #include "gamepad.h"
+#include "list.h"
 #include "types.h"
 #include "utils.h"
 #include "window.h"
+
+DefList(Gamepad, GamepadList)
 
 bool GamepadConnected(Gamepad* gamepad) {
     return gamepad->connected;

--- a/src/gamepad.c
+++ b/src/gamepad.c
@@ -4,7 +4,7 @@
 #include "utils.h"
 #include "window.h"
 
-DefList(Gamepad, GamepadList)
+DefList(Gamepad, GamepadList);
 
 bool GamepadConnected(Gamepad* gamepad) {
     return gamepad->connected;
@@ -38,4 +38,9 @@ float32 GamepadAxisValue(Gamepad* gamepad, GamepadAxis axis) {
         return gamepad->axes[axis];
     }
     return false;
+}
+
+void GamepadSetVibration(Gamepad* gamepad, float32 leftMotor, float32 rightMotor) {
+    gamepad->leftMotor = clamp(leftMotor, 0, 1);
+    gamepad->rightMotor = clamp(rightMotor, 0, 1);
 }

--- a/src/list.c
+++ b/src/list.c
@@ -1,0 +1,97 @@
+#include <stdlib.h>
+#include <string.h>
+
+#include "types.h"
+#include "list.h"
+
+typedef struct List {
+    byte* data;
+    const int itemSize;
+    int len;
+    int cap;
+} List;
+
+bool ListInit(List* list, int itemSize, int len, int cap) {
+    cap = cap < len ? len : cap;
+    List init = {
+        .itemSize = itemSize,
+        .cap = cap,
+        .len = len,
+    };
+    memcpy(list, &init, sizeof(List));
+    if (cap > 0) {
+        list->data = (byte*)malloc(itemSize * cap);
+        if (list->data == nil) return false;
+        memset(list->data, 0, itemSize * cap);
+    }
+    return true;
+}
+
+void* ListGet(List* list, int index) {
+    if (index > list->cap || index < 0) return nil;
+    return &list->data[index * list->itemSize];
+}
+
+void ListFree(List* list) {
+    if (list->data == nil) return;
+    free(list->data);
+    list->data = nil;
+    list->len = list->cap = 0;
+}
+
+bool ListGrow(List* list, int newCap) {
+    if (newCap < list->cap) return true;
+    byte* newPtr = (byte*)malloc(newCap * list->itemSize);
+    if (newPtr == nil) return false;
+    memset(newPtr, 0, newCap * list->itemSize);
+    memcpy(newPtr, list->data, list->cap * list->itemSize);
+    free(list->data);
+    list->data = newPtr;
+    list->cap = newCap;
+    return true;
+}
+
+bool ListPush(List* list, void* item) {
+    const int index = list->len * list->itemSize;
+    if (list->len + 1 > list->cap) {
+        int newCap = (list->len * 3) / 2 + 1;
+        if (ListGrow(list, newCap) == false) return false;
+    }
+    list->len++;
+    memcpy(&list->data[index], item, list->itemSize);
+    return true;
+}
+
+bool ListPop(List* list, void* dest) {
+    if (list->len == 0) return false;
+    const int index = list->len * list->itemSize;
+    list->len--;
+    if (dest != nil) memcpy(dest, &list->data[index], list->itemSize);
+    // zero out removed element
+    memset(&list->data[index], 0, list->itemSize);
+    return true;
+}
+
+bool ListUnshift(List* list, void* item) {
+    if (list->len + 1 > list->cap) {
+        int newCap;
+        if (list->cap > 0)
+            newCap = (list->len * 3) / 2;
+        else
+            newCap = 1;
+        if (ListGrow(list, newCap) == false) return false;
+    }
+    memmove(&list->data[list->itemSize], list->data, list->itemSize * list->len);
+    memcpy(list->data, item, list->itemSize);
+    return true;
+}
+
+bool ListShift(List* list, void* dest) {
+    if (list->len == 0) return false;
+    if (dest != nil) memcpy(dest, list->data, list->itemSize);
+    memmove(list->data, &list->data[list->itemSize], list->itemSize * list->len);
+    list->len--;
+    // clean end of list
+    memset(&list->data[list->len * list->itemSize], 0, list->itemSize);
+    return true;
+}

--- a/src/list.c
+++ b/src/list.c
@@ -28,7 +28,7 @@ bool ListInit(List* list, int itemSize, int len, int cap) {
 }
 
 void* ListGet(List* list, int index) {
-    if (index > list->cap || index < 0) return nil;
+    if (index >= list->cap || index < 0) return nil;
     return &list->data[index * list->itemSize];
 }
 

--- a/src/list.c
+++ b/src/list.c
@@ -4,26 +4,22 @@
 #include "types.h"
 #include "list.h"
 
-typedef struct List {
-    byte* data;
-    const int itemSize;
-    int len;
-    int cap;
-} List;
-
 bool ListInit(List* list, int itemSize, int len, int cap) {
     cap = cap < len ? len : cap;
-    List init = {
-        .itemSize = itemSize,
-        .cap = cap,
-        .len = len,
-    };
-    memcpy(list, &init, sizeof(List));
+    void* ptr = nil;
     if (cap > 0) {
-        list->data = (byte*)malloc(itemSize * cap);
-        if (list->data == nil) return false;
-        memset(list->data, 0, itemSize * cap);
+        ptr = (byte*)malloc(itemSize * cap);
+        if (ptr == nil) return false;
+        memset(ptr, 0, itemSize * cap);
     }
+    memcpy(list,
+        &(List){
+            .data = ptr,
+            .itemSize = itemSize,
+            .cap = cap,
+            .len = len,
+        },
+        sizeof(List));
     return true;
 }
 
@@ -35,8 +31,15 @@ void* ListGet(List* list, int index) {
 void ListFree(List* list) {
     if (list->data == nil) return;
     free(list->data);
-    list->data = nil;
-    list->len = list->cap = 0;
+
+    memcpy(list,
+        &(List){
+            .data = nil,
+            .itemSize = list->itemSize,
+            .cap = 0,
+            .len = 0,
+        },
+        sizeof(List));
 }
 
 bool ListGrow(List* list, int newCap) {
@@ -46,8 +49,14 @@ bool ListGrow(List* list, int newCap) {
     memset(newPtr, 0, newCap * list->itemSize);
     memcpy(newPtr, list->data, list->cap * list->itemSize);
     free(list->data);
-    list->data = newPtr;
-    list->cap = newCap;
+    memcpy(list,
+        &(List){
+            .data = newPtr,
+            .itemSize = list->itemSize,
+            .cap = newCap,
+            .len = list->len,
+        },
+        sizeof(List));
     return true;
 }
 
@@ -57,18 +66,32 @@ bool ListPush(List* list, void* item) {
         int newCap = (list->len * 3) / 2 + 1;
         if (ListGrow(list, newCap) == false) return false;
     }
-    list->len++;
     memcpy(&list->data[index], item, list->itemSize);
+    memcpy(list,
+        &(List){
+            .data = list->data,
+            .itemSize = list->itemSize,
+            .cap = list->cap,
+            .len = list->len + 1,
+        },
+        sizeof(List));
     return true;
 }
 
 bool ListPop(List* list, void* dest) {
     if (list->len == 0) return false;
     const int index = list->len * list->itemSize;
-    list->len--;
     if (dest != nil) memcpy(dest, &list->data[index], list->itemSize);
     // zero out removed element
     memset(&list->data[index], 0, list->itemSize);
+    memcpy(list,
+        &(List){
+            .data = list->data,
+            .itemSize = list->itemSize,
+            .cap = list->cap,
+            .len = list->len - 1,
+        },
+        sizeof(List));
     return true;
 }
 
@@ -83,6 +106,14 @@ bool ListUnshift(List* list, void* item) {
     }
     memmove(&list->data[list->itemSize], list->data, list->itemSize * list->len);
     memcpy(list->data, item, list->itemSize);
+    memcpy(list,
+        &(List){
+            .data = list->data,
+            .itemSize = list->itemSize,
+            .cap = list->cap,
+            .len = list->len + 1,
+        },
+        sizeof(List));
     return true;
 }
 
@@ -90,7 +121,14 @@ bool ListShift(List* list, void* dest) {
     if (list->len == 0) return false;
     if (dest != nil) memcpy(dest, list->data, list->itemSize);
     memmove(list->data, &list->data[list->itemSize], list->itemSize * list->len);
-    list->len--;
+    memcpy(list,
+        &(List){
+            .data = list->data,
+            .itemSize = list->itemSize,
+            .cap = list->cap,
+            .len = list->len + 1,
+        },
+        sizeof(List));
     // clean end of list
     memset(&list->data[list->len * list->itemSize], 0, list->itemSize);
     return true;

--- a/src/main.c
+++ b/src/main.c
@@ -29,6 +29,27 @@ Audio audio;
 //         .type = SineOscillator,
 //     },
 // };
+#include <execinfo.h>
+void print_trace(void) {
+    void *array[10];
+    size_t size;
+    char **strings;
+    size_t i;
+
+    size = backtrace(array, 10);
+    strings = backtrace_symbols(array, size);
+
+    printf("Obtained %zd stack frames.\n", size);
+
+    for (i = 0; i < size; i++) {
+        printf("%s\n", strings[i]);
+    }
+}
+
+struct GamepadNative {
+    int fileDescriptor;
+    char serial[32];
+};
 
 int main(void) {
     println("Starting game");
@@ -51,6 +72,15 @@ int main(void) {
     // Aff3Print(aff3);
     while (WindowUpdate(&window)) {
         int64 begin = WindowTime();
+
+        println("*** In main ***");
+        println("gamepadCount: %d", window.gamepadCount);
+        println("gamepadPtr: %p", window.gamepads);
+        for (int i = 0; i < window.gamepadCount; i++) {
+            println("gamepad [%d] native: %p", i, window.gamepads[i].native);
+            println("gamepad [%d] serial: %s", i, window.gamepads[i].native->serial);
+        }
+        // if (window.gamepadCount > 0) break;
 
         // int availableAudio = AudioAvailable(&audio);
         // if (availableAudio > 0) {
@@ -123,11 +153,18 @@ int main(void) {
         // GraphicsEnd();
 
         int64 now = WindowTime();
-        if (now - begin < 1000 / 60 && 1000 / 60 - (now - begin) > 0) {
-            WindowSleep(1000 / 60 - (now - begin));
+        if (now - begin < 2000 && 2000 - (now - begin) > 0) {
+            WindowSleep(2000 - (now - begin));
         }
     }
 
+    println("*** After main ***");
+    println("gamepadCount: %d", window.gamepadCount);
+    println("gamepadPtr: %p", window.gamepads);
+    for (int i = 0; i < window.gamepadCount; i++) {
+        println("gamepad [%d] native: %p", i, window.gamepads[i].native);
+        println("gamepad [%d] serial: %s", i, window.gamepads[i].native->serial);
+    }
     // GraphicsClose(&window);
     // AudioClose(&audio);
     WindowClose(&window);

--- a/src/main.c
+++ b/src/main.c
@@ -72,15 +72,7 @@ int main(void) {
     // Aff3Print(aff3);
     while (WindowUpdate(&window)) {
         int64 begin = WindowTime();
-
-        println("*** In main ***");
-        println("gamepadCount: %d", window.gamepadCount);
-        println("gamepadPtr: %p", window.gamepads);
-        for (int i = 0; i < window.gamepadCount; i++) {
-            println("gamepad [%d] native: %p", i, window.gamepads[i].native);
-            println("gamepad [%d] serial: %s", i, window.gamepads[i].native->serial);
-        }
-        // if (window.gamepadCount > 0) break;
+        // if (window.gamepads.len > 0) break;
 
         // int availableAudio = AudioAvailable(&audio);
         // if (availableAudio > 0) {
@@ -156,14 +148,6 @@ int main(void) {
         if (now - begin < 2000 && 2000 - (now - begin) > 0) {
             WindowSleep(2000 - (now - begin));
         }
-    }
-
-    println("*** After main ***");
-    println("gamepadCount: %d", window.gamepadCount);
-    println("gamepadPtr: %p", window.gamepads);
-    for (int i = 0; i < window.gamepadCount; i++) {
-        println("gamepad [%d] native: %p", i, window.gamepads[i].native);
-        println("gamepad [%d] serial: %s", i, window.gamepads[i].native->serial);
     }
     // GraphicsClose(&window);
     // AudioClose(&audio);

--- a/src/main.c
+++ b/src/main.c
@@ -29,27 +29,6 @@ Audio audio;
 //         .type = SineOscillator,
 //     },
 // };
-#include <execinfo.h>
-void print_trace(void) {
-    void *array[10];
-    size_t size;
-    char **strings;
-    size_t i;
-
-    size = backtrace(array, 10);
-    strings = backtrace_symbols(array, size);
-
-    printf("Obtained %zd stack frames.\n", size);
-
-    for (i = 0; i < size; i++) {
-        printf("%s\n", strings[i]);
-    }
-}
-
-struct GamepadNative {
-    int fileDescriptor;
-    char serial[32];
-};
 
 int main(void) {
     println("Starting game");
@@ -111,24 +90,28 @@ int main(void) {
 
         print("Mouse: { X: %d, Y: %d }\r", window.mouseX, window.mouseY);
 
-        // Gamepad *gamepad = WindowGetFirstConnectedGamepad(&window);
-        // if (gamepad && gamepad->connected) {
-        //     bool APressed = GamepadButtonPressed(gamepad, GAMEPAD_A);
-        //     bool BPressed = GamepadButtonPressed(gamepad, GAMEPAD_B);
-        //     bool XPressed = GamepadButtonPressed(gamepad, GAMEPAD_X);
-        //     bool YPressed = GamepadButtonPressed(gamepad, GAMEPAD_Y);
-        //     println("Gamepad connected: (Buttons: %s, %s, %s, %s), Left stick: (X: % .6f, Y: % .6f), Right stick: (X: % .6f, Y: % .6f)",
-        //         APressed ? "A" : " ",
-        //         BPressed ? "B" : " ",
-        //         XPressed ? "X" : " ",
-        //         YPressed ? "Y" : " ",
-        //         GamepadAxisValue(gamepad, GAMEPAD_AXIS_LEFT_STICK_X),
-        //         GamepadAxisValue(gamepad, GAMEPAD_AXIS_LEFT_STICK_Y),
-        //         GamepadAxisValue(gamepad, GAMEPAD_AXIS_RIGHT_STICK_X),
-        //         GamepadAxisValue(gamepad, GAMEPAD_AXIS_RIGHT_STICK_Y));
-        // } else {
-        //     println("No gamepads connected");
-        // }
+        Gamepad *gamepad = WindowGetFirstConnectedGamepad(&window);
+        if (gamepad && gamepad->connected) {
+            // bool APressed = GamepadButtonPressed(gamepad, GAMEPAD_A);
+            // bool BPressed = GamepadButtonPressed(gamepad, GAMEPAD_B);
+            // bool XPressed = GamepadButtonPressed(gamepad, GAMEPAD_X);
+            // bool YPressed = GamepadButtonPressed(gamepad, GAMEPAD_Y);
+            // println("Gamepad connected: (Buttons: %s, %s, %s, %s), Left stick: (X: % .6f, Y: % .6f), Right stick: (X: % .6f, Y: % .6f)",
+            //     APressed ? "A" : " ",
+            //     BPressed ? "B" : " ",
+            //     XPressed ? "X" : " ",
+            //     YPressed ? "Y" : " ",
+            //     GamepadAxisValue(gamepad, GAMEPAD_AXIS_LEFT_STICK_X),
+            //     GamepadAxisValue(gamepad, GAMEPAD_AXIS_LEFT_STICK_Y),
+            //     GamepadAxisValue(gamepad, GAMEPAD_AXIS_RIGHT_STICK_X),
+            //     GamepadAxisValue(gamepad, GAMEPAD_AXIS_RIGHT_STICK_Y));
+            // println("0x%04lX", gamepad->buttons);
+            GamepadSetVibration(gamepad,
+                GamepadAxisValue(gamepad, GAMEPAD_AXIS_LEFT_TRIGGER),
+                GamepadAxisValue(gamepad, GAMEPAD_AXIS_RIGHT_TRIGGER));
+        } else {
+            println("No gamepads connected");
+        }
 
         // GraphicsClear(&window);
         // GraphicsBegin(&window);
@@ -145,8 +128,8 @@ int main(void) {
         // GraphicsEnd();
 
         int64 now = WindowTime();
-        if (now - begin < 2000 && 2000 - (now - begin) > 0) {
-            WindowSleep(2000 - (now - begin));
+        if (now - begin < 1000 / 60 && 1000 / 60 - (now - begin) > 0) {
+            WindowSleep(1000 / 60 - (now - begin));
         }
     }
     // GraphicsClose(&window);

--- a/src/main.c
+++ b/src/main.c
@@ -7,6 +7,7 @@
 #include "graphics.h"
 #include "keyboard.h"
 #include "mouse.h"
+#include "types.h"
 #include "utils.h"
 #include "window.h"
 
@@ -90,27 +91,13 @@ int main(void) {
 
         print("Mouse: { X: %d, Y: %d }\r", window.mouseX, window.mouseY);
 
-        Gamepad *gamepad = WindowGetFirstConnectedGamepad(&window);
-        if (gamepad && gamepad->connected) {
-            // bool APressed = GamepadButtonPressed(gamepad, GAMEPAD_A);
-            // bool BPressed = GamepadButtonPressed(gamepad, GAMEPAD_B);
-            // bool XPressed = GamepadButtonPressed(gamepad, GAMEPAD_X);
-            // bool YPressed = GamepadButtonPressed(gamepad, GAMEPAD_Y);
-            // println("Gamepad connected: (Buttons: %s, %s, %s, %s), Left stick: (X: % .6f, Y: % .6f), Right stick: (X: % .6f, Y: % .6f)",
-            //     APressed ? "A" : " ",
-            //     BPressed ? "B" : " ",
-            //     XPressed ? "X" : " ",
-            //     YPressed ? "Y" : " ",
-            //     GamepadAxisValue(gamepad, GAMEPAD_AXIS_LEFT_STICK_X),
-            //     GamepadAxisValue(gamepad, GAMEPAD_AXIS_LEFT_STICK_Y),
-            //     GamepadAxisValue(gamepad, GAMEPAD_AXIS_RIGHT_STICK_X),
-            //     GamepadAxisValue(gamepad, GAMEPAD_AXIS_RIGHT_STICK_Y));
-            // println("0x%04lX", gamepad->buttons);
+        Gamepad *gamepad;
+        for (int i = 0, l = GamepadCount(&window); i < l; i++) {
+            gamepad = WindowGetGamepad(&window, i);
+            if (gamepad->connected == false) continue;
             GamepadSetVibration(gamepad,
                 GamepadAxisValue(gamepad, GAMEPAD_AXIS_LEFT_TRIGGER),
                 GamepadAxisValue(gamepad, GAMEPAD_AXIS_RIGHT_TRIGGER));
-        } else {
-            println("No gamepads connected");
         }
 
         // GraphicsClear(&window);

--- a/src/utils.c
+++ b/src/utils.c
@@ -1,4 +1,27 @@
 #include "types.h"
+#include "utils.h"
+#include <stdbool.h>
+#include <string.h>
+#include <strings.h>
+
+void copy(const void *restrict src, void *restrict dst, size_t size) {
+    memcpy(dst, src, size);
+}
+
+void copyPad(const void *restrict src, void *restrict dst, size_t size) {
+    if (src == nil) {
+        for (uint32 i = 0; i < size; i++) {
+            ((byte *)dst)[i] = '\0';
+        }
+    }
+
+    uint32 srclen = strlen(src);
+    if (srclen > size) srclen = size;
+    memcpy(dst, src, srclen);
+    for (uint32 i = srclen; i < size; i++) {
+        ((byte *)dst)[i] = '\0';
+    }
+}
 
 bool bitSet(uint64 bits, uint8 index) {
     uint64 mask = 1 << (uint64)index;
@@ -22,4 +45,11 @@ float32 clamp(float32 value, float32 min, float32 max) {
     if (value > max) return max;
     if (value < min) return min;
     return value;
+}
+
+bool hasPrefix(const char *text, const char *prefix) {
+    if (text == nil || prefix == nil) return false;
+    uint32 prefixLen = strlen(prefix), textLen = strlen(text);
+    if (textLen < prefixLen) return false;
+    return strncmp(text, prefix, prefixLen) == 0;
 }

--- a/src/window.c
+++ b/src/window.c
@@ -56,3 +56,7 @@ Gamepad *WindowGetGamepad(Window *window, int playerID) {
 extern inline Gamepad *WindowGetFirstConnectedGamepad(Window *window) {
     return GamepadListGet(&window->gamepads, 0);
 }
+
+int GamepadCount(Window *window) {
+    return window->gamepads.len;
+}

--- a/src/window.c
+++ b/src/window.c
@@ -50,10 +50,9 @@ rune KeyGetChar(Window *window) {
 }
 
 Gamepad *WindowGetGamepad(Window *window, int playerID) {
-    if (playerID < 0 || playerID > window->gamepadCount) return nil;
-    return &window->gamepads[playerID];
+    return GamepadListGet(&window->gamepads, playerID);
 }
 
 extern inline Gamepad *WindowGetFirstConnectedGamepad(Window *window) {
-    return window->firstGamepad;
+    return GamepadListGet(&window->gamepads, 0);
 }

--- a/src/windowNative.c
+++ b/src/windowNative.c
@@ -1,7 +1,5 @@
-#include <errno.h>
-#include <stdbool.h>
+#include <stdio.h>
 #include <stdlib.h>
-#include <sys/ioctl.h>
 #include <wchar.h>
 
 // X11 also defines a `Window` type that conflicts with Mino. This hack
@@ -42,7 +40,6 @@ static void resetInputState(Window *window) {
         gamepad = GamepadListGet(&window->gamepads, i);
         if (gamepad->connected == false) continue;
         gamepad->pButtons = gamepad->buttons;
-        gamepad->buttons = 0;
         for (int j = 0; j < GAMEPAD_AXIS_COUNT; j++) {
             gamepad->pAxes[j] = gamepad->axes[j];
         }
@@ -386,12 +383,9 @@ void GraphicsAddColor(Color color) {
 // Gotta clean this up so X11 can work. Now `MinoWindow` is the Window for Mino
 // and `Window` is for X11's window ID.
 #undef Window
-#include <X11/Xlib.h>
 #include <X11/Xutil.h>
-#include <X11/XKBlib.h>
-#include <X11/keysym.h>
 
-Key XKey2MinoKey(int key) {
+static Key XKey2MinoKey(int key) {
     switch (key) {
         case XK_a: return KEY_A;
         case XK_b: return KEY_B;
@@ -498,10 +492,9 @@ Key XKey2MinoKey(int key) {
         case XK_slash: return KEY_SLASH;
         case XK_space: return KEY_SPACE;
         case XK_Tab: return KEY_TAB;
+        default: return KEY_INVALID;
     }
-    println("Unhandled keycode: 0x%04X", key);
-    return KEY_INVALID;
-};
+}
 
 // `XKey2MinoKey` needs to be before `#include <linux/input.h>` because it contains defines that collide with Mino.
 #include <linux/input.h>
@@ -510,6 +503,9 @@ Key XKey2MinoKey(int key) {
 #include <libudev.h>
 #include <string.h>
 #include <unistd.h>
+#include <X11/XKBlib.h>
+#include <X11/Xlib.h>
+#include <sys/ioctl.h>
 
 struct WindowNative {
     Display *xDisplay;
@@ -518,6 +514,131 @@ struct WindowNative {
     struct udev *udev;
     struct udev_monitor *monitor;
 };
+
+struct GamepadNative {
+    int fileDescriptor;
+    char *devicePath;
+    struct input_absinfo analogInfos[GAMEPAD_AXIS_COUNT];
+    struct ff_effect rumble;
+};
+
+const int minoAxis2EvdevAxis[GAMEPAD_AXIS_COUNT] = {
+    [GAMEPAD_AXIS_LEFT_STICK_X] = ABS_X,
+    [GAMEPAD_AXIS_LEFT_STICK_Y] = ABS_Y,
+    [GAMEPAD_AXIS_LEFT_TRIGGER] = ABS_Z,
+    [GAMEPAD_AXIS_RIGHT_STICK_X] = ABS_RX,
+    [GAMEPAD_AXIS_RIGHT_STICK_Y] = ABS_RY,
+    [GAMEPAD_AXIS_RIGHT_TRIGGER] = ABS_RZ,
+};
+
+const int evdevAxis2MinoAxis[GAMEPAD_AXIS_COUNT] = {
+    [ABS_X] = GAMEPAD_AXIS_LEFT_STICK_X,
+    [ABS_Y] = GAMEPAD_AXIS_LEFT_STICK_Y,
+    [ABS_Z] = GAMEPAD_AXIS_LEFT_TRIGGER,
+    [ABS_RX] = GAMEPAD_AXIS_RIGHT_STICK_X,
+    [ABS_RY] = GAMEPAD_AXIS_RIGHT_STICK_Y,
+    [ABS_RZ] = GAMEPAD_AXIS_RIGHT_TRIGGER,
+};
+
+GamepadButton evdevButton2MinoButton(int button) {
+    switch (button) {
+        case BTN_A: return GAMEPAD_A;
+        case BTN_B: return GAMEPAD_B;
+        case BTN_X: return GAMEPAD_X;
+        case BTN_Y: return GAMEPAD_Y;
+        case BTN_START: return GAMEPAD_START;
+        case BTN_SELECT: return GAMEPAD_SELECT;
+        case BTN_TL: return GAMEPAD_L1;
+        case BTN_TR: return GAMEPAD_R1;
+        case BTN_TL2: return GAMEPAD_L2;
+        case BTN_TR2: return GAMEPAD_R2;
+        case BTN_THUMBL: return GAMEPAD_L3;
+        case BTN_THUMBR: return GAMEPAD_R3;
+        case BTN_MODE: return GAMEPAD_HOME;
+        default: return GAMEPAD_BUTTON_INVALID;
+    }
+};
+
+const struct input_absinfo fallbackInfos = {
+    .minimum = -1,
+    .maximum = 1,
+};
+
+static void connectController(MinoWindow *window, const char *devicePath) {
+    const int devicePathLen = strlen(devicePath) + 1;
+    Gamepad *gamepad = nil;
+    int fd = open(devicePath, O_RDWR | O_NONBLOCK);
+    if (fd < 0) return;
+
+    // Attempt to reconnect controller with matching file name.
+    for (int i = 0; i < window->gamepads.len; i++) {
+        gamepad = GamepadListGet(&window->gamepads, i);
+        if (gamepad->connected == false && strcmp(gamepad->native->devicePath, devicePath) == 0) {
+            goto foundGamepad;
+        }
+    }
+
+    // If no controllers have this file name, attempt to reconnect
+    // with any disconnected controller.
+    for (int i = 0; i < window->gamepads.len; i++) {
+        gamepad = GamepadListGet(&window->gamepads, i);
+        if (gamepad->connected == false) {
+            free(gamepad->native->devicePath);
+            goto replaceGamepad;
+        };
+    }
+
+    // Finally, if no controllers are disconnected, just connect a
+    // new controller.
+    {
+        GamepadListPush(&window->gamepads, (Gamepad){});
+        gamepad = GamepadListGet(&window->gamepads, window->gamepads.len - 1);
+        gamepad->native = malloc(sizeof(GamepadNative));
+        memset(gamepad->native, 0, sizeof(GamepadNative));
+    }
+
+replaceGamepad:
+    gamepad->native->devicePath = malloc(devicePathLen + 1);
+    gamepad->native->devicePath[devicePathLen] = '\0';
+    gamepad->native->rumble = (struct ff_effect){
+        .id = -1,
+        .type = FF_RUMBLE,
+    };
+
+    memcpy(gamepad->native->devicePath, devicePath, devicePathLen);
+
+foundGamepad:;
+    for (GamepadAxis i = 0; i < GAMEPAD_AXIS_COUNT; i++) {
+        if (ioctl(fd, EVIOCGABS(minoAxis2EvdevAxis[i]), &gamepad->native->analogInfos[i])) {
+            gamepad->native->analogInfos[i] = fallbackInfos;
+        };
+    }
+    gamepad->native->fileDescriptor = fd;
+    gamepad->connected = true;
+    
+}
+
+static void disconnectController(MinoWindow *window, const char *devicePath) {
+    Gamepad *gamepad = nil;
+    for (int i = 0; i < window->gamepads.len; i++) {
+        Gamepad *temp = GamepadListGet(&window->gamepads, i);
+        if (temp->connected == true && strcmp(temp->native->devicePath, devicePath) == 0) {
+            gamepad = temp;
+            break;
+        }
+    }
+    if (gamepad == nil) return;
+
+    close(gamepad->native->fileDescriptor);
+    gamepad->native->fileDescriptor = 0;
+    gamepad->connected = false;
+    // just zero these out to be safe so, when a controller reconnects, none of
+    // the buttons or sticks are still held 
+    gamepad->buttons = 0;
+    for (int i = 0; i < GAMEPAD_AXIS_COUNT; i++) {
+        gamepad->axes[i] = 0;
+    }
+}
 
 bool WindowInit(MinoWindow *window, WindowConfig config) {
     Display *xDisplay = XOpenDisplay(nil);
@@ -542,19 +663,12 @@ bool WindowInit(MinoWindow *window, WindowConfig config) {
     XMapWindow(xDisplay, xWindow);
     XSync(xDisplay, xWindow);
 
-    struct udev *udev;
-    struct udev_monitor *monitor;
-
-    udev = udev_new();
+    struct udev *udev = udev_new();
     if (udev == nil) {
         println("Warning: unable to open udev");
         XDestroyWindow(xDisplay, xWindow);
         return false;
     }
-
-    monitor = udev_monitor_new_from_netlink(udev, "udev");
-    udev_monitor_filter_add_match_subsystem_devtype(monitor, "input", nil);
-    udev_monitor_enable_receiving(monitor);
 
     window->native = allocate(WindowNative);
     *window->native = (WindowNative){
@@ -562,81 +676,34 @@ bool WindowInit(MinoWindow *window, WindowConfig config) {
         .xWindow = xWindow,
         .deleteWindow = deleteWindowAtom,
         .udev = udev,
-        .monitor = monitor,
     };
-    GamepadListInit(&window->gamepads, 0, 0);
+    GamepadListInit(&window->gamepads, 0, 4);
+
+    struct udev_enumerate *devices = udev_enumerate_new(udev);
+    udev_enumerate_add_match_subsystem(devices, "input");
+    udev_enumerate_add_match_property(devices, "ID_INPUT_JOYSTICK", "1");
+    udev_enumerate_scan_devices(devices);
+    struct udev_list_entry *entry, *listEntry = udev_enumerate_get_list_entry(devices);
+    struct udev_device *device = NULL;
+    udev_list_entry_foreach(entry, listEntry) {
+        const char *sysPath = udev_list_entry_get_name(entry);
+        device = udev_device_new_from_syspath(udev, sysPath);
+
+        const char *devicePath = udev_device_get_devnode(device);
+        if (hasPrefix(devicePath, "/dev/input/event") == false) goto end;
+
+        connectController(window, devicePath);
+    end:
+        udev_device_unref(device);
+    }
+    udev_enumerate_unref(devices);
+
+    struct udev_monitor *monitor = udev_monitor_new_from_netlink(udev, "udev");
+    udev_monitor_filter_add_match_subsystem_devtype(monitor, "input", nil);
+    udev_monitor_enable_receiving(monitor);
+    window->native->monitor = monitor;
+
     return true;
-}
-
-struct GamepadNative {
-    int fileDescriptor;
-    char *deviceNode;
-};
-
-static void connectController(MinoWindow *window, const char *deviceNode) {
-    const int deviceNodeLen = strlen(deviceNode) + 1;
-    Gamepad *gamepad = nil;
-
-    // Attempt to reconnect controller with matching file name.
-    for (int i = 0; i < window->gamepads.len; i++) {
-        Gamepad *temp = GamepadListGet(&window->gamepads, i);
-        if (temp->connected == false && strcmp(temp->native->deviceNode, deviceNode) == 0) {
-            println("Reconnecting same controller");
-            gamepad = temp;
-            goto foundGamepad;
-        }
-    }
-
-    // If no controllers have this file name, attempt to reconnect
-    // with any disconnected controller.
-    for (int i = 0; i < window->gamepads.len; i++) {
-        Gamepad *temp = GamepadListGet(&window->gamepads, i);
-        if (temp->connected == false) {
-            println("Replacing a controller");
-            gamepad = temp;
-            free(gamepad->native->deviceNode);
-            goto replaceGamepad;
-        };
-    }
-
-    // Finally, if no controllers are disconencted, just connect a
-    // new controller.
-    {
-        println("Creating a new controller");
-        GamepadListPush(&window->gamepads, (Gamepad){});
-        gamepad = GamepadListGet(&window->gamepads, window->gamepads.len - 1);
-        gamepad->native = malloc(sizeof(GamepadNative));
-        memset(gamepad->native, 0, sizeof(GamepadNative));
-    }
-
-replaceGamepad:
-    gamepad->native->deviceNode = malloc(deviceNodeLen + 1);
-    gamepad->native->deviceNode[deviceNodeLen] = '\0';
-    memcpy(gamepad->native->deviceNode, deviceNode, deviceNodeLen);
-
-foundGamepad:
-    gamepad->native->fileDescriptor = open(deviceNode, O_RDONLY | O_NONBLOCK);
-    gamepad->connected = true;
-    println("Added controller located at: %s", gamepad->native->deviceNode);
-}
-
-static void disconnectController(MinoWindow *window, const char *deviceNode) {
-    Gamepad *gamepad = nil;
-    for (int i = 0; i < window->gamepads.len; i++) {
-        Gamepad *temp = GamepadListGet(&window->gamepads, i);
-        if (temp->connected == true && strcmp(temp->native->deviceNode, deviceNode) == 0) {
-            gamepad = temp;
-            break;
-        }
-    }
-    if (gamepad == nil) {
-        println("Disconnected gamepad was never connected");
-        return;
-    }
-    println("Disconnecting controller located at: %s", gamepad->native->deviceNode);
-    close(gamepad->native->fileDescriptor);
-    gamepad->native->fileDescriptor = 0;
-    gamepad->connected = false;
 }
 
 static void refreshControllers(MinoWindow *window) {
@@ -653,25 +720,131 @@ static void refreshControllers(MinoWindow *window) {
             }
 
             const char *isJoystick = udev_device_get_property_value(device, "ID_INPUT_JOYSTICK");
-            if (isJoystick == nil || strcmp(isJoystick, "1") != 0) {
-                udev_device_unref(device);
-                continue;
-            }
+            if (isJoystick == nil || strcmp(isJoystick, "1") != 0) goto end;
 
-            const char *deviceNode = udev_device_get_devnode(device);
-            if (hasPrefix(deviceNode, "/dev/input/event") == false) {
-                udev_device_unref(device);
-                continue;
+            const char *devicePath = udev_device_get_devnode(device);
+            if (hasPrefix(devicePath, "/dev/input/event") == false) {
+                goto end;
             }
 
             action = udev_device_get_action(device);
-            println("action: [%s]", action);
             if (strcmp(action, "add") == 0) {
-                connectController(window, deviceNode);
+                connectController(window, devicePath);
             } else if (strcmp(action, "remove") == 0) {
-                disconnectController(window, deviceNode);
+                disconnectController(window, devicePath);
             }
+        end:
             udev_device_unref(device);
+        }
+    }
+}
+
+static void setAxis(Gamepad *gamepad, struct input_event event) {
+    if (event.code == ABS_HAT0X) {
+        if (event.value >= 1) {
+            gamepad->buttons = unsetBit(gamepad->buttons, GAMEPAD_LEFT);
+            gamepad->buttons = setBit(gamepad->buttons, GAMEPAD_RIGHT);
+        } else if (event.value <= -1) {
+            gamepad->buttons = setBit(gamepad->buttons, GAMEPAD_LEFT);
+            gamepad->buttons = unsetBit(gamepad->buttons, GAMEPAD_RIGHT);
+        } else {
+            gamepad->buttons = unsetBit(gamepad->buttons, GAMEPAD_LEFT);
+            gamepad->buttons = unsetBit(gamepad->buttons, GAMEPAD_RIGHT);
+        }
+        return;
+    } else if (event.code == ABS_HAT0Y) {
+        if (event.value >= 1) {
+            gamepad->buttons = unsetBit(gamepad->buttons, GAMEPAD_DOWN);
+            gamepad->buttons = setBit(gamepad->buttons, GAMEPAD_UP);
+        } else if (event.value <= -1) {
+            gamepad->buttons = setBit(gamepad->buttons, GAMEPAD_DOWN);
+            gamepad->buttons = unsetBit(gamepad->buttons, GAMEPAD_UP);
+        } else {
+            gamepad->buttons = unsetBit(gamepad->buttons, GAMEPAD_DOWN);
+            gamepad->buttons = unsetBit(gamepad->buttons, GAMEPAD_UP);
+        }
+        return;
+    }
+    if (event.code >= GAMEPAD_AXIS_COUNT) return;  // unsupported axis.
+    GamepadAxis axis = evdevAxis2MinoAxis[event.code];
+    struct input_absinfo info = gamepad->native->analogInfos[axis];
+    if (axis == GAMEPAD_AXIS_LEFT_STICK_Y || axis == GAMEPAD_AXIS_RIGHT_STICK_Y) event.value *= -1;
+    if (axis == GAMEPAD_AXIS_LEFT_TRIGGER || axis == GAMEPAD_AXIS_RIGHT_TRIGGER) {
+        gamepad->axes[axis] = clamp((float32)(event.value - info.minimum) / (float32)(info.maximum - info.minimum), 0, 1);
+    } else {
+        gamepad->axes[axis] = clamp((float32)(event.value - info.minimum) / (float32)(info.maximum - info.minimum) * 2.0 - 1.0, -1, 1);
+    }
+    if (axis == GAMEPAD_AXIS_LEFT_TRIGGER) {
+        if (event.value > info.flat)
+            gamepad->buttons = setBit(gamepad->buttons, GAMEPAD_L2);
+        else
+            gamepad->buttons = unsetBit(gamepad->buttons, GAMEPAD_L2);
+    } else if (axis == GAMEPAD_AXIS_RIGHT_TRIGGER) {
+        if (event.value > info.flat)
+            gamepad->buttons = setBit(gamepad->buttons, GAMEPAD_R2);
+        else
+            gamepad->buttons = unsetBit(gamepad->buttons, GAMEPAD_R2);
+    }
+}
+
+static void setButton(Gamepad *gamepad, struct input_event event) {
+    GamepadButton button = evdevButton2MinoButton(event.code);
+    if (button == GAMEPAD_BUTTON_INVALID) return;
+    if (event.value > 0) {
+        gamepad->buttons = setBit(gamepad->buttons, button);
+    } else {
+        gamepad->buttons = unsetBit(gamepad->buttons, button);
+    }
+}
+
+static void setRumble(Gamepad *gamepad) {
+    gamepad->native->rumble.type = FF_RUMBLE;
+    gamepad->native->rumble.replay.length = 0xFFFF;
+    gamepad->native->rumble.u.rumble = (struct ff_rumble_effect){
+        .strong_magnitude = (int32)(gamepad->leftMotor * 0xFFFF),
+        .weak_magnitude = (int32)(gamepad->rightMotor * 0xFFFF),
+    };
+    if (ioctl(gamepad->native->fileDescriptor, EVIOCSFF, &gamepad->native->rumble) < 0) {
+        gamepad->native->rumble.id = -1;
+        if (ioctl(gamepad->native->fileDescriptor, EVIOCSFF, &gamepad->native->rumble) < 0) {
+            return;
+        }
+    };
+    struct input_event event = {
+        .type = EV_FF,
+        .code = gamepad->native->rumble.id,
+        .value = 1,
+    };
+    if(write(gamepad->native->fileDescriptor, &event, sizeof(event)) < 0) {
+        // This if statement is to remove a warning. We don't really need to do
+        // anything if write fails anyway. We'll just ignore it.
+    };
+}
+
+static void updateControllers(MinoWindow *window) {
+    Gamepad *gamepad;
+    struct input_event events[8];
+    for (int i = 0; i < window->gamepads.len; i++) {
+        gamepad = GamepadListGet(&window->gamepads, i);
+        if (gamepad->connected == false) continue;
+        while (true) {
+            int32 bytesRead = read(gamepad->native->fileDescriptor, &events, sizeof(events));
+            if (bytesRead == -1) break;
+            for (int32 i = 0; (i + 1) * (int32)sizeof(struct input_event) < bytesRead; i++) {
+                switch (events[i].type) {
+                    case EV_ABS: {
+                        setAxis(gamepad, events[i]);
+                    } break;
+                    case EV_KEY: {
+                        setButton(gamepad, events[i]);
+                    } break;
+                }
+            }
+        }
+        if (gamepad->leftMotor != gamepad->pLeftMotor || gamepad->rightMotor != gamepad->pRightMotor) {
+            setRumble(gamepad);
+            gamepad->pLeftMotor = gamepad->leftMotor;
+            gamepad->pRightMotor = gamepad->rightMotor;
         }
     }
 }
@@ -681,6 +854,8 @@ bool WindowUpdate(MinoWindow *window) {
     WindowNative *native = window->native;
 
     resetInputState(window);
+    refreshControllers(window);
+    updateControllers(window);
     while (XPending(native->xDisplay)) {
         XNextEvent(native->xDisplay, &event);
         switch (event.type) {
@@ -746,10 +921,8 @@ bool WindowUpdate(MinoWindow *window) {
             case KeyRelease: {
                 KeySym keySymbol = XkbKeycodeToKeysym(native->xDisplay, event.xkey.keycode, 0, 0);
                 Key key = XKey2MinoKey(keySymbol);
-                if (key == KEY_INVALID) {
-                    println("Unhandled keycode: %d", key);
-                    break;
-                }
+                if (key == KEY_INVALID) break;
+
                 window->keyPressed[key] = event.type == KeyPress;
 
                 if (key == KEY_LEFT_CONTROL || key == KEY_RIGHT_CONTROL)
@@ -771,9 +944,9 @@ bool WindowUpdate(MinoWindow *window) {
                     (bitSet(event.xkey.state, Mod5MapIndex) ? MOD_SCROLL_LOCK : 0);
 
                 if (event.type == KeyPress) {
-                    char buffer[2];
+                    char buffer[sizeof(rune)];
                     if (XLookupString(&event.xkey, buffer, sizeof(buffer), &keySymbol, NULL) > 0) {
-                        mbstowcs(&window->keyChar, buffer, sizeof(window->keyChar));
+                        mbstowcs(&window->keyChar, buffer, 1);
                     };
                 }
             } break;
@@ -785,7 +958,6 @@ bool WindowUpdate(MinoWindow *window) {
             } break;
         }
     }
-    refreshControllers(window);
     return true;
 }
 
@@ -799,9 +971,9 @@ void WindowClose(MinoWindow *window) {
             close(gamepad->native->fileDescriptor);
         }
         if (gamepad->native != nil) {
-            if (gamepad->native->deviceNode != nil) {
-                free(gamepad->native->deviceNode);
-                gamepad->native->deviceNode = nil;
+            if (gamepad->native->devicePath != nil) {
+                free(gamepad->native->devicePath);
+                gamepad->native->devicePath = nil;
             }
             free(gamepad->native);
             gamepad->native = nil;

--- a/src/windowNative.c
+++ b/src/windowNative.c
@@ -497,15 +497,15 @@ static Key XKey2MinoKey(int key) {
 }
 
 // `XKey2MinoKey` needs to be before `#include <linux/input.h>` because it contains defines that collide with Mino.
-#include <linux/input.h>
-#include <linux/types.h>
 #include <fcntl.h>
 #include <libudev.h>
+#include <linux/input.h>
+#include <linux/types.h>
 #include <string.h>
+#include <sys/ioctl.h>
 #include <unistd.h>
 #include <X11/XKBlib.h>
 #include <X11/Xlib.h>
-#include <sys/ioctl.h>
 
 struct WindowNative {
     Display *xDisplay;


### PR DESCRIPTION
Finally finished support for gamepads on Linux. It supports connecting and disconnecting controllers automatically, listening to buttons and axis input, and setting vibrations for both the left and right motors.

Currently tested with a PS4 DualShock and an Xbox Series controller.